### PR TITLE
#137090907: modify eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
   "extends": "airbnb-base",
   "env": {
     "node": true,
-    "es6": true,
     "mocha": true
   },
   "rules": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "view-helpers": "~0.1.3"
   },
   "devDependencies": {
+    "eslint": "^3.13.1",
     "bcryptjs": "^1.0.5",
     "browser-sync": "^2.18.6",
     "connect-flash": "^0.1.1",


### PR DESCRIPTION
### What does this PR do?
This is a chore that modifies eslint configuration file to avoid `es6` errors from HoundCI.

### What are the relevant pivotal tracker stories?
137090907

### Any background context you want to provide?
Initial configuration leads to eslint es6 errors.  