### PR TITLE
Feature/137090923/start game

### DIFF
--- a/app/controllers/start-game.js
+++ b/app/controllers/start-game.js
@@ -1,0 +1,86 @@
+/*
+* Module dependencies.
+*/
+const mongoose = require('mongoose');
+
+const GameRecords = mongoose.model('Records');
+
+/*
+* Find Game Records by Gameid
+*/
+exports.getGameRecords = (req, res) => {
+  const gameID = req.params.id;
+  GameRecords.findOne({
+    gameID
+  }, (err, savedGame) => {
+    if (err) {
+      return res.send(err);
+    }
+    if (!savedGame) {
+      return res.status(400).json({
+        success: false,
+        message: 'Game Record Not Found!!'
+      });
+    } else {
+      return res.status(200).json(savedGame);
+    }
+  });
+};
+/*
+* Store Game Record
+*/
+exports.saveRecords = (req, res) => {
+  const gameID = req.body.gameID,
+    players = req.body.players,
+    completed = req.body.completed,
+    winner = req.body.winner,
+    rounds = req.body.rounds;
+
+  const gameRecord = new GameRecords({
+    gameID,
+    players,
+    completed,
+    rounds,
+    winner
+  });
+
+  gameRecord.save((err, data) => {
+    if (err) {
+      return res.send(err);
+    }
+    return res.status(201).json({
+      success: true,
+      data,
+      message: 'Thanks for starting a game!'
+    });
+  });
+};
+
+/*
+ * Update Game Record
+*/
+exports.updateRecords = (req, res) => {
+  const gameID = req.body.gameID;
+  const completed = req.body.completed;
+  const winner = req.body.winner;
+  const rounds = req.body.rounds;
+
+  GameRecords.update({
+    gameID
+  }, {
+    $set: {
+      completed,
+      rounds,
+      winner
+    }
+  }, (err, data) => {
+    if (err) {
+      return res.send(err);
+    }
+    return res.status(201).json({
+      success: true,
+      message: 'Gamer Record updated',
+      data
+    });
+  });
+};

--- a/app/models/start.js
+++ b/app/models/start.js
@@ -1,0 +1,18 @@
+/**
+ * Module dependencies.
+ */
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+/**
+ * Game Record Schema
+ */
+const RecordSchema = new Schema({
+  gameID: String,
+  players: [],
+  completed: Boolean,
+  rounds: Number,
+  winner: String
+});
+
+module.exports = mongoose.model('Records', RecordSchema);

--- a/config/routes.js
+++ b/config/routes.js
@@ -97,4 +97,8 @@ module.exports = function(app, passport, auth) {
      //loginAuth Routes
     var authLogin = require('../app/controllers/loginAuth');
     app.post('/api/auth/login', authLogin.login);
+
+    // Start game Routes
+    const startGame = require('../app/controllers/start-game');
+    app.post('/api/games/:id/start', startGame.start-game);
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -99,6 +99,8 @@ module.exports = function(app, passport, auth) {
     app.post('/api/auth/login', authLogin.login);
 
     // Start game Routes
-    const startGame = require('../app/controllers/start-game');
-    app.post('/api/games/:id/start', startGame.start-game);
+  const startGame = require('../app/controllers/start-game');
+  app.get('/api/games/:id', startGame.getGameRecords);
+  app.post('/api/games/:id/start', startGame.saveRecords);
+  app.post('/api/games/:id/end', startGame.updateRecords);
 };

--- a/config/socket/socket.js
+++ b/config/socket/socket.js
@@ -43,6 +43,11 @@ module.exports = function(io) {
       }
     });
 
+    socket.on('startGameManually', function(){
+        gamesNeedingPlayers.shift();
+          game.prepareGame();
+    })
+
     socket.on('joinNewGame', function(data) {
       exitGame(socket);
       joinGame(socket,data);
@@ -130,10 +135,10 @@ module.exports = function(io) {
         game.assignGuestNames();
         game.sendUpdate();
         game.sendNotification(player.username+' has joined the game!');
-        if (game.players.length >= game.playerMaxLimit) {
-          gamesNeedingPlayers.shift();
-          game.prepareGame();
-        }
+        // if (game.players.length >= game.playerMaxLimit) {
+        //   gamesNeedingPlayers.shift();
+        //   game.prepareGame();
+        // }
       } else {
         // TODO: Send an error message back to this user saying the game has already started
       }
@@ -176,10 +181,10 @@ module.exports = function(io) {
       game.assignGuestNames();
       game.sendUpdate();
       game.sendNotification(player.username+' has joined the game!');
-      if (game.players.length >= game.playerMaxLimit) {
-        gamesNeedingPlayers.shift();
-        game.prepareGame();
-      }
+      // if (game.players.length >= game.playerMaxLimit) {
+      //   gamesNeedingPlayers.shift();
+      //   game.prepareGame();
+      // }
     }
   };
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1444,3 +1444,56 @@
  .socials_block{
    margin-left: 300px;
  }
+
+/* The Modal (background) */
+.modal {
+    display: none; /* Hidden by default */
+    position: fixed; /* Stay in place */
+    z-index: 1; /* Sit on top */
+    left: 0;
+    top: 0;
+    width: 100%; /* Full width */
+    height: 100%; /* Full height */
+    overflow: auto; /* Enable scroll if needed */
+    background-color: rgb(0,0,0); /* Fallback color */
+    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+}
+
+/* Modal Content/Box */
+.modal-content {
+    background-color: white;
+    margin: 15% auto; /* 15% from the top and centered */
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%; /* Could be more or less, depending on screen size */
+    color: #002266;
+}
+
+/* The Close Button */
+.close {
+  color: #002266;
+    float: right;
+    font-size: 35px;
+    font-weight: bold;
+}
+
+.close:hover, .start-btn:hover{
+    color: lightblue;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.start-btn{
+  background-color: #002266;
+  color: white;
+  align-content: center;
+  width: 30%;
+  margin-left: 35%;
+  height: 50px;
+  font-size: 25px;
+
+}
+
+.header-text{
+  margin-left: 35%;
+}

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -124,6 +124,10 @@ angular.module('mean.system')
       game.startGame();
     };
 
+       $scope.startGameManually = function() {
+      game.startGameManually();
+    };
+
     $scope.abandonGame = function() {
       game.leaveGame();
       $location.path('/');

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -124,10 +124,6 @@ angular.module('mean.system')
       game.startGame();
     };
 
-       $scope.startGameManually = function() {
-      game.startGameManually();
-    };
-
     $scope.abandonGame = function() {
       game.leaveGame();
       $location.path('/');

--- a/public/js/modal.js
+++ b/public/js/modal.js
@@ -14,6 +14,6 @@ span.onclick = () => {
 
 const start = document.getElementById('start-game');
 
-start.onclick = () => {
-  $scope.startGame = game.startGame();
-};
+// start.onclick = () => {
+// game.startGame();
+// };

--- a/public/js/modal.js
+++ b/public/js/modal.js
@@ -1,0 +1,19 @@
+// Get the modal
+const modal = document.getElementById('myModal');
+
+// Get the <span> element that closes the modal
+const span = document.getElementsByClassName('close')[0];
+
+// Open modal as soon as page opens
+modal.style.display = 'block';
+
+// When the user clicks on <span> (x), close the modal
+span.onclick = () => {
+  modal.style.display = 'none';
+};
+
+const start = document.getElementById('start-game');
+
+start.onclick = () => {
+  $scope.startGame = game.startGame();
+};

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -185,6 +185,10 @@ angular.module('mean.system')
     socket.emit(mode,{userID: userID, room: room, createPrivate: createPrivate});
   };
 
+game.startGameManually = function(){
+    socket.emit('startGameManually');
+}
+
   game.startGame = function() {
     socket.emit('startGame');
   };

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -168,6 +168,27 @@ angular.module('mean.system')
         game.joinOverride = true;
       }, 15000);
     } else if (data.state === 'game dissolved' || data.state === 'game ended') {
+      if (data.state === 'game ended') {
+            $http({
+              method: 'POST',
+              url: `/api/games/${game.gameID}/end`,
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              data: {
+                gameID: game.gameID,
+                completed: true,
+                rounds: game.round,
+                winner: game.players[game.gameWinner].username
+              }
+            })
+            .success(function (res) {
+              return res;
+            })
+            .error(function (err) {
+              return err;
+            });
+          }
       game.players[game.playerIndex].hand = [];
       game.time = 0;
     }
@@ -185,13 +206,39 @@ angular.module('mean.system')
     socket.emit(mode,{userID: userID, room: room, createPrivate: createPrivate});
   };
 
-game.startGameManually = function(){
-    socket.emit('startGameManually');
-}
+// game.startGameManually = function(){
+//     socket.emit('startGameManually');
+// }
 
-  game.startGame = function() {
+    game.startGame = function() {
     socket.emit('startGame');
   };
+
+    game.saveGame = () => {
+      socket.emit('startGame');
+      if (window.user) {
+        $http({
+          method: 'POST',
+          url: `/api/games/${game.gameID}/start`,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          data: {
+            gameID: game.gameID,
+            players: game.players,
+            completed: false,
+            rounds: 0,
+            winner: ''
+          }
+        })
+          .success((res) => {
+            return res;
+          })
+          .error((err) => {
+            return err;
+          });
+      }
+    };
 
   game.leaveGame = function() {
     game.players = [];

--- a/public/views/app.html
+++ b/public/views/app.html
@@ -1,4 +1,23 @@
 </script>
+
+<!-- The Modal -->
+<div id="myModal" class="modal">
+
+  <!-- Modal content -->
+  <div class="modal-content">
+    <div class="modal-head">
+      <span class="close">&times;</span>
+       <h2><span class="header-text">Welcome..</span></h2>
+    </div>
+    <div class="modal-body">
+      <h4><span class="text">You are about starting a new Game Session... Please click on the Start Game button below</span></h4>
+      <button id="start-game" type="button" class="btn start-btn">Start game</button>
+    </div>
+  </div>
+
+</div>
+
+
 <div id="app-container" ng-controller="GameController">
   <!-- Add home header here-->
   <!-- Fixed Logo & Menu Bar Start -->
@@ -46,3 +65,5 @@
 <answers></answers>
 </div>
 </div>
+
+<script type="text/javascript" src="../js/modal.js"></script>

--- a/public/views/app.html
+++ b/public/views/app.html
@@ -1,6 +1,10 @@
 </script>
 
-<!-- The Modal -->
+
+
+
+<div id="app-container" ng-controller="GameController">
+  <!-- The Modal -->
 <div id="myModal" class="modal">
 
   <!-- Modal content -->
@@ -11,14 +15,11 @@
     </div>
     <div class="modal-body">
       <h4><span class="text">You are about starting a new Game Session... Please click on the Start Game button below</span></h4>
-      <button id="start-game" type="button" class="btn start-btn">Start game</button>
+      <button ng-click="startGame()" id="start-game" type="button" class="btn start-btn">Start game</button>
     </div>
   </div>
 
 </div>
-
-
-<div id="app-container" ng-controller="GameController">
   <!-- Add home header here-->
   <!-- Fixed Logo & Menu Bar Start -->
   <div class="navigationDiv row  padNavBottom">


### PR DESCRIPTION
### What does this PR do?
This PR allows users to be able to start a new game session after login or signup
### Description of Task to be completed?
Users should be able to start a new game session after login or signup. 
Currently the game throws you into a new gaming screen and starts the game off immediately, which creates a rather confusing experience for the user. 
The task was done using Authenticated End Points, Functions and Bootsrap Modals
### How should this be manually tested?
This can be tested via Postman. (screenshot attached)
### Any background context you want to provide?
No
### What are the relevant pivotal tracker stories?
Users should be able to create/start a new game   #137090923
### Screenshots (if appropriate)
<img width="970" alt="screenshot 2017-02-13 19 58 48" src="https://cloud.githubusercontent.com/assets/24937779/22906049/1488897a-f243-11e6-858e-bb377bd3a846.png">

<img width="974" alt="screenshot 2017-02-13 20 02 06" src="https://cloud.githubusercontent.com/assets/24937779/22906187/bcdba986-f243-11e6-97ab-2e051c69f923.png">


### Questions:
No
