### PR TITLE
feat(onboarding): add more onboarding steps

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -32,6 +32,17 @@
      font-family: 'fa', sans-serif;
  }
 
+  .screen-tour-button {
+    font-family: 'Lobster', cursive;
+    border: 2px solid black;
+    border-radius: 5px;
+    color: #002266;
+    background-color: #FF9999;
+    height: 40px;
+    width: 120px;
+    font-size: 1.5em;
+  }
+
  .fa-down-open:before { content: '\e800'; } /* '' */
 
  #info-container {

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -234,8 +234,7 @@ $dialog, playerSearch, invitePlayer, $window, $http) => {
     $scope.startTour = () => {
       const tour = new Shepherd.Tour({
         defaults: {
-          classes: 'shepherd-theme-default',
-          scrollTo: true
+          classes: 'shepherd-theme-default'
         }
       });
       tour.addStep('Step 1', {
@@ -243,7 +242,6 @@ $dialog, playerSearch, invitePlayer, $window, $http) => {
         text: `This button starts the game when there are up
        to 3 players ready to play`,
         attachTo: '#start-game-container bottom',
-        classes: 'shepherd-theme-default',
         showCancelLink: true,
         buttons: [
           {
@@ -257,18 +255,100 @@ $dialog, playerSearch, invitePlayer, $window, $http) => {
         text: `Here is an indicator of how many players have
        joined the game out of 12 maximum players allowed.`,
         attachTo: '#player-count-container bottom',
-        // classes: 'example-step-extra-class',
         showCancelLink: true,
         buttons: [
           {
             text: 'Back',
             action: tour.back,
-          // classes:
+          },
+          {
+            text: 'Next',
+            action: tour.next,
+          }
+        ]
+      });
+      tour.addStep('Step 3', {
+        title: 'Game Timer',
+        text: `This is a countdown timer that shows how much
+         time is remaining for you to choose a card.`,
+        attachTo: '#timer-container left',
+        showCancelLink: true,
+        buttons: [
+          {
+            text: 'Back',
+            action: tour.back,
+          },
+          {
+            text: 'Next',
+            action: tour.next,
+          }
+        ]
+      });
+      tour.addStep('Step 4', {
+        title: 'Chat window',
+        text: `Here is a chat window where you can view
+         conversations between players in the game, including you.`,
+        attachTo: '#chat-body right',
+        showCancelLink: true,
+        buttons: [
+          {
+            text: 'Back',
+            action: tour.back,
+          },
+          {
+            text: 'Next',
+            action: tour.next,
+          }
+        ]
+      });
+      tour.addStep('Step 5', {
+        title: 'Chat message',
+        text: `This is a chat input box where you can type in messages
+         you want to send to the chat widow for all players to see.`,
+        attachTo: '#chat-footer right',
+        showCancelLink: true,
+        buttons: [
+          {
+            text: 'Back',
+            action: tour.back,
+          },
+          {
+            text: 'Next',
+            action: tour.next,
+          }
+        ]
+      });
+      tour.addStep('Step 6', {
+        title: 'Game History',
+        text: 'The game log shows you your game history.',
+        attachTo: '#gameLogButton bottom',
+        showCancelLink: true,
+        buttons: [
+          {
+            text: 'Back',
+            action: tour.back,
+          },
+          {
+            text: 'Next',
+            action: tour.next,
+          }
+        ]
+      });
+      tour.addStep('Step 7', {
+        title: 'Abandon Game',
+        text: `Click this button to Leave the game. 
+          You will not be able to get back into this 
+          game if it has already started`,
+        attachTo: '#abandon-game-button right',
+        showCancelLink: true,
+        buttons: [
+          {
+            text: 'Back',
+            action: tour.back,
           },
           {
             text: 'Done',
             action: tour.complete,
-          // classes:
           }
         ]
       });

--- a/public/views/answers.html
+++ b/public/views/answers.html
@@ -79,7 +79,7 @@
         game!
       </li>
     </ol>
-    <button ng-click="startTour()">Screen Tour</button>
+    <button ng-click="startTour()" class="screen-tour-button">Screen Tour</button>
   </div>
 </div>
 <div id="game-end-container" ng-show="game.state === 'game ended' || game.state ==='game dissolved'">


### PR DESCRIPTION
### What does this PR do?
- It adds more steps required to onboard a user to the gaming interface and controls
### Description of Task to be completed?
- Add Shepherd(a tour aid application) and use it to describe the application interface and controls in defined steps
### How should this be manually tested?
- Click the 'Screen Tour' button at the bottom of the gaming screen to start the tour. A pop-up window pointing at an element or control on the screen appears, showing a written description of control and an clickable options to end the tour or move to the next item on the tour.
### Any background context you want to provide?
- N/A
### What are the relevant pivotal tracker stories?
- #137090931 Users should be quickly and effectively onboarded onto the app
### Screenshots (if appropriate)
<img width="673" alt="screen shot 2017-02-15 at 1 44 59 pm" src="https://cloud.githubusercontent.com/assets/24937744/22974946/fc3dbc58-f384-11e6-8960-78d312feb5e6.png">
### Questions:
- N/A