### PR TITLE
#140636141/game log

### DIFF
--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -294,9 +294,7 @@ angular.module('mean.system')
           card: card.id
         });
       };
-
       decrementTime();
-
       return game;
     }
   ]);

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -255,24 +255,6 @@ angular.module('mean.system')
         game.players = [];
         game.time = 0;
         socket.emit('leaveGame');
-        $http({
-          method: 'POST',
-          url: `/api/games/${game.gameID}/end`,
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          data: {
-            gameID: game.gameID,
-            players: game.players,
-            completed: true,
-            rounds: game.round,
-            winner: game.gameWinner
-          }
-        })
-          .success((res) => {
-            return res;
-          })
-          .error(err => err);
       };
 
       game.drawCard = () => {

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -251,6 +251,7 @@ angular.module('mean.system')
             return err;
           });
       };
+
       game.leaveGame = () => {
         game.players = [];
         game.time = 0;


### PR DESCRIPTION
### What does this PR do?
Fixes the updating on the database when a user abandons game.

### Description of Task to be completed?
The database only get updated when the game ends.

### How should this be manually tested?
Users that abandons game before the game officially ends would not get a record for that game session.

### Any background context you want to provide?
The game currently updates the database when the user abandons game and when the game ends. Therefore, when the user clicks on game log, so many uncompleted game sessions are displayed.

### What are the relevant pivotal tracker stories?
Given that the database is populated when you abandon game and when game ends
It should only get populated when the game ends

### Screenshots (if appropriate)
N/A

### Questions:
N/A
